### PR TITLE
Fix code scanning alert no. 17: Failure to use HTTPS or SFTP URL in Maven artifact upload/download

### DIFF
--- a/platforms/software/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolUpgrade/some-thing/pom.xml
+++ b/platforms/software/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolUpgrade/some-thing/pom.xml
@@ -27,7 +27,7 @@
             <id>local-remote</id>
             <name>Local Test Repository</name>
             <layout>default</layout>
-            <url>http://www.example.com/maven/repo</url>
+            <url>https://www.example.com/maven/repo</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Fixes [https://github.com/akaday/gradle/security/code-scanning/17](https://github.com/akaday/gradle/security/code-scanning/17)

To fix the problem, we need to replace the insecure HTTP URL with a secure HTTPS URL. This change ensures that the communication with the repository is encrypted and secure, preventing potential MITM attacks. Specifically, we will update the `<url>` tag within the `<repository>` section to use HTTPS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
