### PR TITLE
Fix code scanning alert no. 11: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/impl/AbstractZipEntry.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/impl/AbstractZipEntry.java
@@ -40,7 +40,11 @@ abstract class AbstractZipEntry implements ZipEntry {
 
     @Override
     public String getName() {
-        return entry.getName();
+        String name = entry.getName();
+        if (name.contains("..") || name.startsWith("/") || name.startsWith("\\")) {
+            throw new IllegalArgumentException("Invalid entry name: " + name);
+        }
+        return name;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InPlaceClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InPlaceClasspathBuilder.java
@@ -157,7 +157,10 @@ public class InPlaceClasspathBuilder implements ClasspathBuilder {
 
         @Override
         public void put(String name, byte[] content, CompressionMethod compressionMethod) throws IOException {
-            File target = new File(baseDir, name);
+            File target = new File(baseDir, name).getCanonicalFile();
+            if (!target.toPath().startsWith(baseDir.toPath())) {
+                throw new IllegalArgumentException("Invalid entry name: " + name);
+            }
             if (target.exists()) {
                 throw new IllegalArgumentException("Duplicate entry " + name);
             }


### PR DESCRIPTION
Fixes [https://github.com/akaday/gradle/security/code-scanning/11](https://github.com/akaday/gradle/security/code-scanning/11)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. This can be achieved by verifying that the normalized full path of the output file starts with a prefix that matches the destination directory.

1. Modify the `getName()` method in `AbstractZipEntry.java` to return a sanitized version of the entry name.
2. Ensure that the `put` method in `InPlaceClasspathBuilder.java` validates the constructed file path before performing any file operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
